### PR TITLE
Remove `* { position: relative; }`

### DIFF
--- a/src/css/elements/_elements.page.scss
+++ b/src/css/elements/_elements.page.scss
@@ -1,7 +1,3 @@
-* {
-  position: relative;
-}
-
 html,
 body {
   // height: 100%;


### PR DESCRIPTION
I propose we remove this from puppy. Any objections? It would only affect new projects and personally I'd like to avoid using `* {...}` where possible since it feels like a bit of a bad habit.